### PR TITLE
Add connected IP display to boot sequence; confirm mDNS

### DIFF
--- a/Load_Touch_xTask_V3a/myLWifi.h
+++ b/Load_Touch_xTask_V3a/myLWifi.h
@@ -76,13 +76,10 @@ bool wifiBegin(){
       screenError("Failed to connect\nto saved LANs", ERR_BG_A, 5, false);     
    }
    else // normal connect to existing LAN
-   { 
+{ 
       String sss = WiFi.SSID();
       const char * ssp = sss.c_str();
       strcpy(myID.local_ssid, ssp);    
-      sprintf(buf, "Connected to local LAN\nSSID = %s\n", myID.local_ssid);
-      SDEBUG1.printf(buf);
-      screenError(buf, ERR_BG_A, 1, false);
       myIP = WiFi.localIP();
 	    myBroadcastIP = WiFi.broadcastIP();
 	    mySubnetMask = WiFi.subnetMask();
@@ -90,6 +87,9 @@ bool wifiBegin(){
 		  //Serial.println(myBroadcastIP);
 			MDNS.begin(myID.instName);		
 	    setHostNameIP();
+      sprintf(buf, "Connected to local LAN\nSSID = %s\nIP = %s\n", myID.local_ssid, IPstring);
+      SDEBUG1.printf(buf);
+      screenError(buf, ERR_BG_A, 2, false);
       wifiStatus = WIFI_CONN;
       WifiConnected = true;
 //	    strcpy(pSet.conn_ssid, myID.local_ssid);
@@ -98,7 +98,6 @@ bool wifiBegin(){
 		  WiFi.printDiag(SDEBUG1);
 	    return true;
    }
-
    // Failed LAN - set up local ESPNET
 	 feedLoopWDT();
    WiFi.disconnect();
@@ -134,10 +133,13 @@ bool wifiBegin(){
 			mySubnetMask = cidr2netmask(WiFi.softAPSubnetCIDR());
 			WiFi.softAPsetHostname(myID.instName);
 			IamAP = true;				
-			MDNS.begin(myID.instName);
+            MDNS.begin(myID.instName);
 			setHostNameIP ();
-      wifiStatus = WIFI_SOFTAP;
-      WifiConnected = true;
+			sprintf(buf, "Started Access Point\nSSID = %s\nIP = %s\n", myWiFi[0].ssid, IPstring);
+			SDEBUG1.printf(buf);
+			screenError(buf, ERR_BG_A, 2, false);
+            wifiStatus = WIFI_SOFTAP;
+            WifiConnected = true;
 //			strcpy(pSet.conn_ssid, myID.esp_ssid);
 			updateWiFi(myWiFi[0].ssid, "", false);
 		 // printStoredWiFi();


### PR DESCRIPTION
## WiFi mechanism review: confirm mDNS, add IP to boot display

### Task 1: mDNS
Confirmed mDNS (ESPmDNS) is already correctly implemented in
myLWiFi.h - both the LAN-connect and softAP-fallback paths call
MDNS.begin(myID.instName). No changes needed.

### Task 2: Display connected IP before main screen
Previously the boot splash showed only model/version, with no WiFi
awareness, and the "Connected" status message displayed before the
IP address had even been read. This PR:
- Reorders the LAN-connect branch so IP/hostname is resolved before
  building the status message
- Adds "IP = %s" to both the LAN-connect and softAP-fallback status
  screens
- Changes the display duration, 
- I wasn't sure how that works, but it stays on the screen longer now. Let me know if this isn't appropriate.
### Testing
- Compiles and flashes cleanly
- Verified IP displays correctly on the LAN-connect path
- (softAP fallback path implemented identically, verify before merge
  if not yet flash-tested on that path)

Ray (& Claude)